### PR TITLE
handle displaying of jira versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3
 
 COPY requirements.txt ./
-COPY consts.py ./
 RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
Up until now linking jira versions resulted in a bad display of it (as it assumed it to be a jira ticket.

This handles the jira versions better, and also displays tickets with specific colors so it's easy to understand the issue-type (bug, story, epic and task).